### PR TITLE
Remove os-firewall from required_plugins (obsolete)

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -12,7 +12,6 @@ opnsense::haproxy:
   backends: {}
   frontends: {}
 opnsense::required_plugins:
-  "os-firewall": {}
   "os-haproxy": {}
   "os-node_exporter": {}
 opnsense::api_manager_prefix: "%{fqdn} api manager - "

--- a/spec/classes/opnsense_spec.rb
+++ b/spec/classes/opnsense_spec.rb
@@ -36,9 +36,6 @@ describe 'opnsense' do
               'device' => 'opnsense.example.com',
               'ensure' => 'absent',
             )
-          is_expected.to contain_opnsense_plugin('os-firewall').with(
-              'device' => 'opnsense.example.com',
-            )
           is_expected.to contain_opnsense_plugin('os-haproxy').with(
               'device' => 'opnsense.example.com',
             )


### PR DESCRIPTION
Since OPNsense has integrated the 'os-firewall' plugin into the core system with version 24.1, I propose removing it from the list of required plugins