### PR TITLE
Fix required plugins

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -12,7 +12,6 @@ opnsense::haproxy:
   backends: {}
   frontends: {}
 opnsense::required_plugins:
-  "os-firewall": {}
   "os-haproxy": {}
   "os-node_exporter": {}
 opnsense::api_manager_prefix: "%{fqdn} api manager - "

--- a/lib/facter/opnsense.rb
+++ b/lib/facter/opnsense.rb
@@ -7,7 +7,7 @@ Facter.add(:opnsense) do
     end
 
     facts = {}
-    opn_ver = Facter::Core::Execution.exec("#{opnsense_version} -NAVvfH")
+    opn_ver = Facter::Core::Execution.exec("#{opnsense_version} -NAVvH")
     if opn_ver
       facts['name'] = opn_ver.split(' ')[0]
       facts['architecture'] = opn_ver.split(' ')[1]
@@ -15,8 +15,7 @@ Facter.add(:opnsense) do
       release['major'] = opn_ver.split(' ')[2]
       release['full'] = opn_ver.split(' ')[3]
       release['minor'] = opn_ver.split(' ')[3].split('.')[2]
-      release['flavour'] = opn_ver.split(' ')[4]
-      release['hash'] = opn_ver.split(' ')[5]
+      release['hash'] = opn_ver.split(' ')[4]
       facts['release'] = release if release
     end
 

--- a/spec/classes/opnsense_spec.rb
+++ b/spec/classes/opnsense_spec.rb
@@ -36,9 +36,6 @@ describe 'opnsense' do
               'device' => 'opnsense.example.com',
               'ensure' => 'absent',
             )
-          is_expected.to contain_opnsense_plugin('os-firewall').with(
-              'device' => 'opnsense.example.com',
-            )
           is_expected.to contain_opnsense_plugin('os-haproxy').with(
               'device' => 'opnsense.example.com',
             )


### PR DESCRIPTION
Since OPNsense has integrated the 'os-firewall' plugin into the core system with version 24.1, I propose removing it from the list of required plugins 